### PR TITLE
[Fix] python-package creator: install *.bin and *.dat files

### DIFF
--- a/src/linux/installer/setup.py.template
+++ b/src/linux/installer/setup.py.template
@@ -107,6 +107,8 @@ setup(
         'subprocess',
         '*.so',
         '*.pak',
+        '*.bin',
+        '*.dat',
         'debug.log',
         'examples/debug.log',
         'examples/wx/debug.log',


### PR DESCRIPTION
if not available, we get an error like this: 
[0629/133450:ERROR:icu_util.cc(183)] Invalid file descriptor to ICU data received.