### PR TITLE
Extended Javascript Bindings features (#367)

### DIFF
--- a/Authors
+++ b/Authors
@@ -13,3 +13,4 @@ Greg Farrell <gregfarrell.org@@gmail.com>
 Finn Hughes <finn.hughes1@@gmail.com>
 Marcelo Fernandez <fernandezm@@gmail.com>
 Simon Hatt <9hatt2@@gmail.com>
+Andrew Leech <andrew@@alelec.net>

--- a/api/JavascriptBindings.md
+++ b/api/JavascriptBindings.md
@@ -81,7 +81,7 @@ Call this to rebind javascript bindings. This is useful when using reload() on p
 
 There is an another way of doing rebinding, you can call [Frame](Frame.md).SetProperty(), but this is not best performant way as it creates a C++ class V8FunctionHandler for each function, when doing Rebind() there is only one such class created. [Frame](Frame.md).SetProperty() is also more limited, you cannot bind objects using it, though it could be supported, I'm wondering whether there is a need for that, it would allow to pass objects as arguments to javascript callbacks so maybe it will be implemented in the future. Also Rebind() does bindings to frames and popups automatically according to bindToFrames and bindToPopups constructor options, while using [Frame](Frame.md).SetProperty() you would need to take care of that by yourself.
 
-Rebind does not solve all scenarios, take for example: what happens if you pass a python callback to javascript and then do rebindings? You still get old function referenced in javascript.
+Rebind does not solve all scenarios, take for example: what happens if you pass a python callback to javascript and then do call rebind? You still get old function referenced in javascript.
 
 
 ### SetFunction
@@ -92,7 +92,7 @@ Rebind does not solve all scenarios, take for example: what happens if you pass 
 | func | function|method |
 | __Return__ | void |
 
-This function will be binded to window object in html, you can call it in two ways:
+This function will be bound to window object in html, you can call it in two ways:
 
 ```
 window.myfunc()
@@ -118,7 +118,7 @@ This function is dummy, it really calls SetProperty(), you might use it as well 
 | --- | --- |
 | name | string |
 | object | instance |
-| allow_properties | bool=False |
+| allow_properties | bool (default False) |
 | __Return__ | void |
 
 Normally this function binds only methods of an object. If `allow_properties` is set properties will be copied during binding also.
@@ -133,12 +133,12 @@ Example:
 	myobject.someMethod();
 ```
 
-By default when binding object only methods are bound unless `allow_properties` is explicitely set. This was done as properties can currently ounly be bound by copying value during the binding process. It is expected this could be confusing as accessing object's property from javascript might give a different value during runtime then the real value when getting the property from python runtime if either end has been changed in the mean time. Only object's methods and functions can be bound by reference currently.  
+By default when binding object only methods are bound unless `allow_properties` is explicitly set. This was done as properties can currently only be bound by copying value during the binding process. It is expected this could be confusing as accessing object's property from javascript might give a different value during runtime than the real value when getting the property from python runtime if either end has been changed in the mean time. Only object's methods and functions can be bound by reference currently.  
 If so desired the properties can be bound just be aware that the javascript object will only be able to access the values as they existed at the time binding was performed. Changes to the javascript or python copies of the properties will not be reflected on the other.
 
 ```
 # In python:
-	class MyObject(object):
+    class MyObject(object):
         def __init__(self):
             self.definition = "a property"
 
@@ -152,7 +152,9 @@ If so desired the properties can be bound just be aware that the javascript obje
 	myobject = MyObject()
 	bindings.SetObject("myobject", myobject, allow_properties=True)
 	browser.SetJavascriptBindings(bindings)
-	myobject.definition = "changed property"  # js will not see this
+	
+	# js will not see this change unless you call browser.Rebind()
+	myobject.definition = "changed property" 
     
 	// In javasript:
 	window.myobject.definition == "a property";
@@ -189,7 +191,7 @@ If the python object has the special function `__call__` the javascript object w
 | value | mixed |
 | __Return__ | void |
 
-Set some value to property of the window object in html. This propertiy  for example can hold configuration options or some other data required at startup of your application.
+Set some value to property of the window object in html. This property  for example can hold configuration options or some other data required at startup of your application.
 
 Mixed type is one that can be converted to javascript types, see IsValueAllowed() for a full list.
 

--- a/src/javascript_bindings.pyx
+++ b/src/javascript_bindings.pyx
@@ -103,6 +103,8 @@ cdef class JavascriptBindings:
                 attrs = {}
                 for name, value in self.objects[objectName].items():
                     if self.IsValueAllowedRecursively(value):
+                        if inspect.ismethod(value):
+                            value = '####cefpython####{"what": "bound-function"}'
                         attrs[name] = value
                 objects[objectName] = attrs
             pyBrowser.SendProcessMessage(cef_types.PID_RENDERER,

--- a/src/javascript_bindings.pyx
+++ b/src/javascript_bindings.pyx
@@ -102,7 +102,8 @@ cdef class JavascriptBindings:
             for objectName in self.objects:
                 attrs = {}
                 for name, value in self.objects[objectName].items():
-                    if self.IsValueAllowedRecursively(value):
+                    if self.IsValueAllowedRecursively(value) and \
+                            name == '__call__' or not name.startswith('_'):
                         if inspect.ismethod(value):
                             value = '####cefpython####{"what": "bound-function"}'
                         attrs[name] = value

--- a/src/javascript_bindings.pyx
+++ b/src/javascript_bindings.pyx
@@ -30,14 +30,14 @@ cdef class JavascriptBindings:
         self.SetProperty(name, func)
 
     cpdef py_void SetObject(self, py_string name, object obj,
-                            object allow_properties=False):
+                            py_bool allow_properties=False):
         if not hasattr(obj, "__class__"):
             raise Exception("JavascriptBindings.SetObject() failed: name=%s, "
                             "__class__ attribute missing, this is not an object" % name)
         cdef dict methods = {}
         cdef py_string key
         cdef object method
-        cdef object predicate = None if allow_properties else inspect.ismethod
+        cdef object predicate = False if allow_properties else inspect.ismethod
         if isinstance(obj, (PyBrowser, PyFrame)):
             predicate = inspect.isbuiltin
         for value in inspect.getmembers(obj, predicate=predicate):

--- a/src/subprocess/cefpython_app.cpp
+++ b/src/subprocess/cefpython_app.cpp
@@ -598,24 +598,6 @@ void CefPythonApp::DoJavascriptBindingsForFrame(CefRefPtr<CefBrowser> browser,
         v8Base->SetValue(functionName, v8Function,
                 V8_PROPERTY_ATTRIBUTE_NONE);
     }
-    // PROPERTIES.
-    CefRefPtr<CefV8Value> v8Properties = CefDictionaryValueToV8Value(
-            properties);
-    std::vector<CefString> v8Keys;
-    if (!v8Properties->GetKeys(v8Keys)) {
-        LOG(ERROR) << "[Renderer process] DoJavascriptBindingsForFrame():"
-                      " v8Properties->GetKeys() failed";
-        if (didEnterContext)
-            context->Exit();
-        return;
-    }
-    for (std::vector<CefString>::iterator it = v8Keys.begin(); \
-            it != v8Keys.end(); ++it) {
-        CefString v8Key = *it;
-        CefRefPtr<CefV8Value> v8Base = GetBaseObject(v8Key, v8Window);
-        CefRefPtr<CefV8Value> v8Value = v8Properties->GetValue(v8Key);
-        v8Base->SetValue(v8Key, v8Value, V8_PROPERTY_ATTRIBUTE_NONE);
-    }
     // OBJECTS AND ITS METHODS.
     std::vector<CefString> objectsVector;
     if (!objects->GetKeys(objectsVector)) {
@@ -660,6 +642,24 @@ void CefPythonApp::DoJavascriptBindingsForFrame(CefRefPtr<CefBrowser> browser,
             v8Object->SetValue(methodName, v8Function,
                     V8_PROPERTY_ATTRIBUTE_NONE);
         }
+    }
+    // PROPERTIES.
+    CefRefPtr<CefV8Value> v8Properties = CefDictionaryValueToV8Value(
+            properties);
+    std::vector<CefString> v8Keys;
+    if (!v8Properties->GetKeys(v8Keys)) {
+        LOG(ERROR) << "[Renderer process] DoJavascriptBindingsForFrame():"
+                      " v8Properties->GetKeys() failed";
+        if (didEnterContext)
+            context->Exit();
+        return;
+    }
+    for (std::vector<CefString>::iterator it = v8Keys.begin(); \
+            it != v8Keys.end(); ++it) {
+        CefString v8Key = *it;
+        CefRefPtr<CefV8Value> v8Value = v8Properties->GetValue(v8Key);
+        CefRefPtr<CefV8Value> v8Base = GetBaseObject(v8Key, v8Window);
+        v8Base->SetValue(v8Key, v8Value, V8_PROPERTY_ATTRIBUTE_NONE);
     }
     // END.
     if (didEnterContext)

--- a/unittests/main_test.py
+++ b/unittests/main_test.py
@@ -14,7 +14,7 @@ import base64
 import sys
 
 # To show the window for an extended period of time increase this number.
-MESSAGE_LOOP_RANGE = 200  # each iteration is 0.01 sec
+MESSAGE_LOOP_RANGE = 300  # each iteration is 0.01 sec
 
 # language=HTML
 g_datauri_data = """
@@ -90,15 +90,15 @@ g_datauri_data = """
         if (obj_with_props.property_is_string !== "string") {
             throw new Error("obj_with_props.property_is_string was not 'string'"); 
         }        
-        if (obj_with_props._not_exposed !== undefined) {
-            throw new Error("obj_with_props._not_exposed was not available to js"); 
-        }
         var counter = obj_with_props.property_evaluated_at_binding;
         if (!Number.isInteger(counter)) {
             throw new Error("obj_with_props.property_evaluated_at_binding was not expected integer"); 
         }
         if (obj_with_props.property_evaluated_at_binding != counter) {
             throw new Error("obj_with_props.property_evaluated_at_binding changed on second read"); 
+        }
+        if (obj_with_props.changed != true) {
+            throw new Error("obj_with_props.changed is still false"); 
         }
         print("window.obj_with_props ok");
 
@@ -179,6 +179,11 @@ class MainTest_IsolatedTest(unittest.TestCase):
         bindings.SetObject("obj_with_props", obj_with_props, allow_properties=True)
         browser.SetJavascriptBindings(bindings)
         subtest_message("browser.SetJavascriptBindings() ok")
+
+        # Test changed object value
+        obj_with_props.changed = True
+        browser.javascriptBindings.Rebind()
+        subtest_message("browser.javascriptBindings.Rebind() ok")
 
         # Run message loop for some time.
         # noinspection PyTypeChecker
@@ -383,7 +388,8 @@ class ObjWithProps(object):
         self.property_is_true = True
         self.property_is_string = "string"
 
-        self._not_exposed = True
+        self.changed = False
+
         self._counter = 0
 
     @property


### PR DESCRIPTION
This patchset adds some extended options for binding python objects to the browser.
* Allow python/javascript objects to be callable if the python class has `__call__()` function
* Allow optional bind-time-only copying of properties from python object to javascript one.

For more details see Issue #367 and forum: 
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/cefpython/HVUePvzRXbc 