### PR TITLE
Add option --use-ccache for faster (re)builds

### DIFF
--- a/tools/automate.py
+++ b/tools/automate.py
@@ -35,6 +35,7 @@ Usage:
                 [--gyp-msvs-version MSVS]
                 [--use-system-freetype USE_SYSTEM_FREETYPE]
                 [--use-gtk3 USE_GTK3]
+                [--use-ccache USE_CCACHE]
                 [--no-depot-tools-update NO_DEPOT_TOOLS_UPDATE]
     automate.py (-h | --help) [type -h to show full description for options]
 
@@ -68,6 +69,7 @@ Options:
     --gyp-msvs-version=<v>   Set GYP_MSVS_VERSION.
     --use-system-freetype    Use system Freetype library on Linux (Issue #402)
     --use-gtk3               Link CEF with GTK 3 libraries (Issue #446)
+    --use-ccache             Use ccache for faster (re)builds
     --no-depot-tools-update  Do not update depot_tools/ directory. When
                              building old unsupported versions of Chromium
                              you want to manually checkout an old version
@@ -116,6 +118,7 @@ class Options(object):
     gyp_msvs_version = ""     # env variables are being used.
     use_system_freetype = False
     use_gtk3 = False
+    use_ccache = False
     no_depot_tools_update = False
 
     # Internal options
@@ -905,6 +908,10 @@ def getenv():
     # Link with GTK 3 (Issue #446)
     if Options.use_gtk3:
         env["GN_DEFINES"] += " use_gtk3=true"
+
+    # Use ccache for faster (re)builds
+    if Options.use_ccache:
+        env["GN_DEFINES"] += " cc_wrapper=ccache"
 
     # To perform an official build set GYP_DEFINES=buildtype=Official.
     # This will disable debugging code and enable additional link-time


### PR DESCRIPTION
This patch adds an option to use ccache for caching build objects, which tremendously speeds up rebuilds. (~30-100x, depending on hardware)