### PR TITLE
Add support for Python 3.8 and Upgrade Cython

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ support old operating systems then choose the v31 release.
 
 OS | Py2 | Py3 | 32bit | 64bit | Requirements
 --- | --- | --- | --- | --- | ---
-Windows | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 | Yes | Yes | Windows 7+
-Linux | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 | Yes | Yes | Debian 8+, Ubuntu 14.04+,<br> Fedora 24+, openSUSE 13.3+
-Mac | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 | No | Yes | MacOS 10.9+
+Windows | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 / 3.8 | Yes | Yes | Windows 7+
+Linux | 2.7 | 3.4 / 3.5 / 3.6 / 3.7  3.8 | Yes | Yes | Debian 8+, Ubuntu 14.04+,<br> Fedora 24+, openSUSE 13.3+
+Mac | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 / 3.8 | No | Yes | MacOS 10.9+
 
 These platforms are not supported yet:
 - ARM - see [Issue #267](../../issues/267)

--- a/src/client_handler/Makefile
+++ b/src/client_handler/Makefile
@@ -37,6 +37,7 @@ INC = -I./../ -I./../common/ -I$(PYTHON_INCLUDE) \
 	-I/usr/include/glib-2.0 \
 	-I/usr/include/cairo \
 	-I/usr/include/pango-1.0 \
+	-I/usr/include/harfbuzz \
 	-I/usr/include/gdk-pixbuf-2.0 \
 	-I/usr/include/atk-1.0 \
 	-I/usr/lib/x86_64-linux-gnu/gtk-2.0/include \

--- a/src/common/cefpython_public_api.h
+++ b/src/common/cefpython_public_api.h
@@ -46,6 +46,8 @@
 #include "../../build/build_cefpython/cefpython_py36_fixed.h"
 #elif PY_MINOR_VERSION == 7
 #include "../../build/build_cefpython/cefpython_py37_fixed.h"
+#elif PY_MINOR_VERSION == 8
+#include "../../build/build_cefpython/cefpython_py38_fixed.h"
 #endif // PY_MINOR_VERSION
 #endif // PY_MAJOR_VERSION
 

--- a/src/cpp_utils/Makefile
+++ b/src/cpp_utils/Makefile
@@ -7,7 +7,7 @@ OUT = libcpp_utils.a
 INC = -I./../ -I/usr/include/gtk-2.0 \
 	-I/usr/include/glib-2.0 -I/usr/lib/i386-linux-gnu/gtk-2.0/include \
 	-I/usr/lib/i386-linux-gnu/glib-2.0/include -I/usr/include/cairo \
-	-I/usr/include/pango-1.0 -I/usr/include/gdk-pixbuf-2.0 \
+	-I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/gdk-pixbuf-2.0 \
 	-I/usr/include/atk-1.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include \
 	-I/usr/lib/x86_64-linux-gnu/gtk-2.0/include \
 	-I/usr/lib64/glib-2.0/include -I/usr/lib64/gtk-2.0/include \

--- a/src/subprocess/Makefile
+++ b/src/subprocess/Makefile
@@ -11,6 +11,7 @@ INC = -I./../ -I./../common/ -I$(PYTHON_INCLUDE) \
 	-I/usr/include/glib-2.0 \
 	-I/usr/include/cairo \
 	-I/usr/include/pango-1.0 \
+	-I/usr/include/harfbuzz \
 	-I/usr/include/gdk-pixbuf-2.0 \
 	-I/usr/include/atk-1.0 \
 	-I/usr/lib/x86_64-linux-gnu/gtk-2.0/include \

--- a/src/subprocess/Makefile-libcefpythonapp
+++ b/src/subprocess/Makefile-libcefpythonapp
@@ -36,6 +36,7 @@ INC = -I./../ -I./../common/ -I$(PYTHON_INCLUDE) \
 	-I/usr/include/glib-2.0 \
 	-I/usr/include/cairo \
 	-I/usr/include/pango-1.0 \
+	-I/usr/include/harfbuzz \
 	-I/usr/include/gdk-pixbuf-2.0 \
 	-I/usr/include/atk-1.0 \
 	-I/usr/lib/x86_64-linux-gnu/gtk-2.0/include \

--- a/tools/build.py
+++ b/tools/build.py
@@ -293,7 +293,7 @@ def setup_environ():
         print("[build.py] PYTHON_INCLUDE: {python_include}"
               .format(python_include=os.environ["PYTHON_INCLUDE"]))
 
-        os.environ["CEF_CCFLAGS"] = "-std=gnu++11 -DNDEBUG -Wall -Werror"
+        os.environ["CEF_CCFLAGS"] = "-std=gnu++11 -DNDEBUG -Wall -Werror -Wno-deprecated-declarations"
         if FAST_FLAG:
             os.environ["CEF_CCFLAGS"] += " -O0"
         else:

--- a/tools/build_distrib.py
+++ b/tools/build_distrib.py
@@ -80,7 +80,7 @@ NO_AUTOMATE = False
 ALLOW_PARTIAL = False
 
 # Python versions
-SUPPORTED_PYTHON_VERSIONS = [(2, 7), (3, 4), (3, 5), (3, 6), (3, 7)]
+SUPPORTED_PYTHON_VERSIONS = [(2, 7), (3, 4), (3, 5), (3, 6), (3, 7), (3, 8)]
 
 # Python search paths. It will use first Python found for specific version.
 # Supports replacement of one environment variable in path eg.: %ENV_KEY%.

--- a/tools/common.py
+++ b/tools/common.py
@@ -473,6 +473,8 @@ def get_msvs_for_python(vs_prefix=False):
         return "VS2015" if vs_prefix else "2015"
     elif sys.version_info[:2] == (3, 7):
         return "VS2015" if vs_prefix else "2015"
+    elif sys.version_info[:2] == (3, 8):
+        return "VS2015" if vs_prefix else "2015"
     else:
         print("ERROR: This version of Python is not supported")
         sys.exit(1)

--- a/tools/cython_setup.py
+++ b/tools/cython_setup.py
@@ -318,6 +318,7 @@ def get_include_dirs():
             '/usr/include/gtk-unix-print-2.0',
             '/usr/include/cairo',
             '/usr/include/pango-1.0',
+            '/usr/include/harfbuzz',
             '/usr/include/gdk-pixbuf-2.0',
             '/usr/include/atk-1.0',
             # Fedora
@@ -337,6 +338,7 @@ def get_include_dirs():
             '/usr/include/gtk-unix-print-2.0',
             '/usr/include/cairo',
             '/usr/include/pango-1.0',
+            '/usr/include/harfbuzz',
             '/usr/include/gdk-pixbuf-2.0',
             '/usr/include/atk-1.0',
             # Ubuntu

--- a/tools/installer/cefpython3.__init__.py
+++ b/tools/installer/cefpython3.__init__.py
@@ -60,5 +60,8 @@ elif sys.version_info[:2] == (3, 6):
 elif sys.version_info[:2] == (3, 7):
     # noinspection PyUnresolvedReferences
     from . import cefpython_py37 as cefpython
+elif sys.version_info[:2] == (3, 8):
+    # noinspection PyUnresolvedReferences
+    from . import cefpython_py38 as cefpython
 else:
     raise Exception("Python version not supported: " + sys.version)

--- a/tools/installer/cefpython3.setup.py
+++ b/tools/installer/cefpython3.setup.py
@@ -148,6 +148,7 @@ def main():
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
             "Topic :: Desktop Environment",
             "Topic :: Internet",
             "Topic :: Internet :: WWW/HTTP",

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,4 @@
-Cython == 0.28.4
+Cython == 0.29.21
 docopt >= 0.6.2
 setuptools
 wheel


### PR DESCRIPTION
Fixes: https://github.com/cztomczak/cefpython/issues/546

Had to include harfbuzz manually as newer Pango change this.
See:
    https://github.com/eiskaltdcpp/eiskaltdcpp/issues/413
    https://gitlab.gnome.org/GNOME/pango/-/issues/387

Also had to add `-Wno-deprecated-declarations` to get this to compile because
of the following errors that didn't seem to be coming from this code directly:

    warning: ‘GTimeVal’ is deprecated: Use 'GDateTime' instead
    warning: ‘GTypeDebugFlags’ is deprecated