### PR TITLE
Update int range detection for Python 3

### DIFF
--- a/Authors
+++ b/Authors
@@ -19,3 +19,4 @@ Contributors:
     Dónal McMullan <https://github.com/donalm>
     nobodyguy <https://github.com/nobodyguy>
     Elliot Woods <https://github.com/elliotwoods>
+    Bryan Koroleski <https://github.com/bryan-koroleski-fivestars>

--- a/src/javascript_bindings.pyx
+++ b/src/javascript_bindings.pyx
@@ -139,11 +139,9 @@ cdef class JavascriptBindings:
         elif valueType == float:
             return True
         elif valueType == int:
-            if PY_MAJOR_VERSION < 3:
-                return True
-            if INT_MIN <= value <= INT_MAX:
-                return True
-            return "long"
+            return True
+        elif valueType == long:
+            return True
         elif valueType == type(None):
             return True
         elif IsFunctionOrMethod(valueType):

--- a/src/javascript_bindings.pyx
+++ b/src/javascript_bindings.pyx
@@ -139,7 +139,11 @@ cdef class JavascriptBindings:
         elif valueType == float:
             return True
         elif valueType == int:
-            return True
+            if PY_MAJOR_VERSION < 3:
+                return True
+            if INT_MIN <= value <= INT_MAX:
+                return True
+            return "long"
         elif valueType == type(None):
             return True
         elif IsFunctionOrMethod(valueType):

--- a/src/process_message_utils.pyx
+++ b/src/process_message_utils.pyx
@@ -238,14 +238,11 @@ cdef CefRefPtr[CefListValue] PyListToCefListValue(
             ret.get().SetNull(index)
         elif valueType == bool:
             ret.get().SetBool(index, bool(value))
-        elif valueType == int:
+        elif valueType == int and PY_MAJOR_VERSION < 3:
             ret.get().SetInt(index, int(value))
         elif valueType == long:
-            # Int32 range is -2147483648..2147483647, we've increased the
-            # minimum size by one as Cython was throwing a warning:
-            # "unary minus operator applied to unsigned type, result still
-            # unsigned".
-            if -2147483647 <= value <= 2147483647:
+            # Int32 range is -2147483648..2147483647
+            if INT_MIN <= value <= INT_MAX:
                 ret.get().SetInt(index, int(value))
             else:
                 # Long values become strings.
@@ -297,14 +294,11 @@ cdef void PyListToExistingCefListValue(
             cefListValue.get().SetNull(index)
         elif valueType == bool:
             cefListValue.get().SetBool(index, bool(value))
-        elif valueType == int:
+        elif valueType == int and PY_MAJOR_VERSION < 3:
             cefListValue.get().SetInt(index, int(value))
         elif valueType == long:
-            # Int32 range is -2147483648..2147483647, we've increased the
-            # minimum size by one as Cython was throwing a warning:
-            # "unary minus operator applied to unsigned type, result still
-            # unsigned".
-            if -2147483647 <= value <= 2147483647:
+            # Int32 range is -2147483648..2147483647
+            if INT_MIN <= value <= INT_MAX:
                 cefListValue.get().SetInt(index, int(value))
             else:
                 # Long values become strings.
@@ -357,14 +351,11 @@ cdef CefRefPtr[CefDictionaryValue] PyDictToCefDictionaryValue(
             ret.get().SetNull(cefKey)
         elif valueType == bool:
             ret.get().SetBool(cefKey, bool(value))
-        elif valueType == int:
+        elif valueType == int and PY_MAJOR_VERSION < 3:
             ret.get().SetInt(cefKey, int(value))
         elif valueType == long:
-            # Int32 range is -2147483648..2147483647, we've increased the
-            # minimum size by one as Cython was throwing a warning:
-            # "unary minus operator applied to unsigned type, result still
-            # unsigned".
-            if -2147483647 <= value <= 2147483647:
+            # Int32 range is -2147483648..2147483647
+            if INT_MIN <= value <= INT_MAX:
                 ret.get().SetInt(cefKey, int(value))
             else:
                 # Long values become strings.

--- a/src/process_message_utils.pyx
+++ b/src/process_message_utils.pyx
@@ -238,9 +238,7 @@ cdef CefRefPtr[CefListValue] PyListToCefListValue(
             ret.get().SetNull(index)
         elif valueType == bool:
             ret.get().SetBool(index, bool(value))
-        elif valueType == int and PY_MAJOR_VERSION < 3:
-            ret.get().SetInt(index, int(value))
-        elif valueType == long:
+        elif valueType == int or valueType == long:  # In Py3 int and long types are the same type.
             # Int32 range is -2147483648..2147483647
             if INT_MIN <= value <= INT_MAX:
                 ret.get().SetInt(index, int(value))
@@ -294,9 +292,7 @@ cdef void PyListToExistingCefListValue(
             cefListValue.get().SetNull(index)
         elif valueType == bool:
             cefListValue.get().SetBool(index, bool(value))
-        elif valueType == int and PY_MAJOR_VERSION < 3:
-            cefListValue.get().SetInt(index, int(value))
-        elif valueType == long:
+        elif valueType == int or valueType == long:  # In Py3 int and long types are the same type.
             # Int32 range is -2147483648..2147483647
             if INT_MIN <= value <= INT_MAX:
                 cefListValue.get().SetInt(index, int(value))
@@ -351,9 +347,7 @@ cdef CefRefPtr[CefDictionaryValue] PyDictToCefDictionaryValue(
             ret.get().SetNull(cefKey)
         elif valueType == bool:
             ret.get().SetBool(cefKey, bool(value))
-        elif valueType == int and PY_MAJOR_VERSION < 3:
-            ret.get().SetInt(cefKey, int(value))
-        elif valueType == long:
+        elif valueType == int or valueType == long:  # In Py3 int and long types are the same type.
             # Int32 range is -2147483648..2147483647
             if INT_MIN <= value <= INT_MAX:
                 ret.get().SetInt(cefKey, int(value))

--- a/tools/cython_setup.py
+++ b/tools/cython_setup.py
@@ -468,6 +468,9 @@ def compile_time_constants():
         # A way around Python 3.2 bug: UNAME_SYSNAME is not set
         contents += 'DEF UNAME_SYSNAME = "%s"\n' % platform.uname()[0]
         contents += 'DEF PY_MAJOR_VERSION = %s\n' % sys.version_info.major
+        contents += 'cdef extern from "limits.h":\n'
+        contents += '    cdef int INT_MIN\n'
+        contents += '    cdef int INT_MAX\n'
         fo.write(contents.encode("utf-8"))
 
 


### PR DESCRIPTION
The type checks in `javascript_bindings.pyx` and `process_message_utils.pyx` currently only work in Python 2. Python 3 unified `int` and `long` into a single arbitrarily sized `int` type. The end result is that these checks fail to detect integers larger than 32-bits. This change:

* Exposes `INT_MIN` and `INT_MAX` from `limits.h`
* Updates the `int` range check to work with both Python 2 and Python 3
* Preserves the behavior of attempting to set properties containing integers outside of the 32-bit int range

I've run the tests and examples on Win10 with Python 3.8.6 32-bit and can confirm this change works as expected. 