### PR TITLE
Make pip upgrade instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ also download packages for offline installation available on the
 [GitHub Releases](../../releases) pages. Command to install with pip:
 
 ```
-pip install cefpython3==66.0
+pip install -U cefpython3
 ```
 
 


### PR DESCRIPTION
Having a set version number (66.0) is bad in case you forget to update your README. This just makes it so anyone installing will always get the latest version.