### PR TITLE
Update the package versions in README and README-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ also download packages for offline installation available on the
 [GitHub Releases](../../releases) pages. Command to install with pip:
 
 ```
-pip install cefpython3==66.0
+pip install cefpython3==66.1
 ```
 
 

--- a/examples/README-examples.md
+++ b/examples/README-examples.md
@@ -17,7 +17,7 @@ Instructions to install the cefpython3 package, clone the repository
 and run the hello_world.py example:
 
 ```
-pip install cefpython3==66.0
+pip install cefpython3==66.1
 git clone https://github.com/cztomczak/cefpython.git
 cd cefpython/examples/
 python hello_world.py


### PR DESCRIPTION
Using an older package version will cause a `Python version not supported: 3.9.9` error


#624 