### PR TITLE
Fix problem with specifying both mode and origin

### DIFF
--- a/src/paint_buffer.pyx
+++ b/src/paint_buffer.pyx
@@ -48,10 +48,15 @@ cdef class PaintBuffer:
                     self.height)
 
         if origin == "bottom-left":
-            if not dest_alloced:
+            if dest_alloced:
+                tmp = <void*>malloc(self.length)
+                FlipBufferUpsideDown(tmp, dest, self.width, self.height)
+                free(dest)
+                dest = tmp
+            else:
                 dest = <void*>malloc(self.length)
                 dest_alloced = True
-            FlipBufferUpsideDown(dest, self.buffer, self.width, self.height)
+                FlipBufferUpsideDown(dest, self.buffer, self.width, self.height)
 
         if dest_alloced:
             ret = (<char*>dest)[:self.length]
@@ -91,10 +96,15 @@ cdef class PaintBuffer:
                     self.height)
 
         if origin == "bottom-left":
-            if not dest_alloced:
+            if dest_alloced:
+                tmp = <void*>malloc(self.length)
+                FlipBufferUpsideDown(tmp, dest, self.width, self.height)
+                free(dest)
+                dest = tmp
+            else:
                 dest = <void*>malloc(self.length)
                 dest_alloced = True
-            FlipBufferUpsideDown(dest, self.buffer, self.width, self.height)
+                FlipBufferUpsideDown(dest, self.buffer, self.width, self.height)
 
         if dest_alloced:
             ret = (<char*>dest)[:self.length]


### PR DESCRIPTION
Currently, invoking `PaintBuffer.GetBytes` with both `mode` and `origin` arguments fails to work as expected since each step uses the original buffer, ignoring the result of the previous step.

I'm not a C programmer so there might be a better way to fix the problem. But at least it looks to work fine on my end.