### PR TITLE
Fix CookieVisitor "Must be called on the IO thread" assertion (fixes #683)

### DIFF
--- a/api/CookieManager.md
+++ b/api/CookieManager.md
@@ -53,7 +53,7 @@ Description from upstream CEF:
 | object | [CookieVisitor](CookieVisitor.md) |
 | __Return__ | bool |
 
-Visit all cookies on the IO thread. The returned cookies are ordered by
+Visit all cookies on the UI thread. The returned cookies are ordered by
 longest path, then by earliest creation date. Returns false if cookies
 cannot be accessed.
 
@@ -72,7 +72,7 @@ destroyed and the `CookieVisitor` callbacks won't be called.
 | object | [CookieVisitor](CookieVisitor.md) |
 | __Return__ | bool |
 
-Visit a subset of cookies on the IO thread. The results are filtered by the
+Visit a subset of cookies on the UI thread. The results are filtered by the
 given url scheme, host, domain and path. If |includeHttpOnly| is true
 HTTP-only cookies will also be included in the results. The returned
 cookies are ordered by longest path, then by earliest creation date.

--- a/api/CookieVisitor.md
+++ b/api/CookieVisitor.md
@@ -28,7 +28,8 @@ Table of contents:
 | delete_cookie_out | list[bool] |
 | __Return__ | bool |
 
-Method that will be called once for each cookie. |count| is the 0-based
+Method that will be called once for each cookie. This method is called on
+the UI thread. |count| is the 0-based
 index for the current cookie. |total| is the total number of cookies.
 Set |delete_cookie_out[0]| to True to delete the cookie currently being visited.
 Return False to stop visiting cookies, True to continue. This method may

--- a/examples/snippets/cookies.py
+++ b/examples/snippets/cookies.py
@@ -43,7 +43,7 @@ class LoadHandler(object):
 
 class CookieVisitor(object):
     def Visit(self, cookie, count, total, delete_cookie_out):
-        """This callback is called on the IO thread."""
+        """This callback is called on the UI thread."""
         print("Cookie {count}/{total}: '{name}', '{value}'"
               .format(count=count+1, total=total, name=cookie.GetName(),
                       value=cookie.GetValue()))

--- a/src/cookie.pyx
+++ b/src/cookie.pyx
@@ -315,7 +315,7 @@ cdef public cpp_bool CookieVisitor_Visit(
     cdef PyCookie pyCookie
     cdef list pyDeleteCookie = [False]
     try:
-        assert IsThread(TID_IO), "Must be called on the IO thread"
+        assert IsThread(TID_UI), "Must be called on the UI thread"
         pyCookieVisitor = GetPyCookieVisitor(cookieVisitorId)
         pyCookie = CreatePyCookie(cookie)
         if pyCookieVisitor:


### PR DESCRIPTION
Fix #683 
Update the assert to TID_UI and fix the related API docs and example docstring that referred to the IO thread.